### PR TITLE
zict 2.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0" %}
+{% set version = "2.1.0" %}
 {% set name = "zict" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8e2969797627c8a663575c2fc6fcb53a05e37cdb83ee65f341fc6e0c3d0ced16
+  sha256: 15b2cc15f95a476fbe0623fd8f771e1e771310bf7a01f95412a0b605b6e47510
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - setuptools
+    - wheel
+    - pip
 
   run:
     - python
@@ -27,6 +29,10 @@ requirements:
 test:
   imports:
     - zict
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
-  noarch: python
+  skip: True  # [py<37]
 
 requirements:
   host:
@@ -29,10 +29,13 @@ test:
     - zict
 
 about:
-  home: http://github.com/mrocklin/zict
-  license: BSD 3-Clause
+  home: https://github.com/mrocklin/zict
+  license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: Composable Dictionary Classes
+  dev_url: https://github.com/dask/zict
+  doc_url: https://zict.readthedocs.io/en/latest/
 
 
 extra:


### PR DESCRIPTION
`zict` version `2.1.0`
1. - [x] check the upstream

https://github.com/dask/zict/tree/2.1.0

2. - [x] check the pinnings

The lowest version of python supported is `python 3.7`
https://github.com/dask/zict/blob/2.1.0/setup.py#L22&&L26

`heapdict` did not had any version restrictions
https://github.com/dask/zict/blob/2.1.0/requirements.txt#L1

3. - [x] check the changelogs
    https://github.com/dask/zict/blob/2.1.0/doc/source/changelog.rst

    The main breaking change mention is the drop of support for `python 3.6` the rest of the changes were only new features or bug fixes.

    - LRU and Buffer now deal with exceptions raised by the callbacks

    - Dropped support for Python 3.6; added support for Python 3.9 and 3.10

    - Migrate to GitHub actions

    - Allow file mmaping
    
4. - [x] additional research
    https://github.com/conda-forge/zict-feedstock/issues

    There are currently no open issues mentioned in the upstream

    We are currently building mainly architecture specific packages. This package will be modify to be an architecture specific package for now. 

5. - [x] verify `dev_url`
    
    The `dev_url` was missing in the recipe. The following url was added to the `meta.yaml` file.

    https://github.com/dask/zict

    
6. - [x] verify `doc_url`
    
    The `doc_url` was missing in the recipe. The following url was added to the `meta.yaml` file.
     https://zict.readthedocs.io/en/latest/

7. - [x] license is `spdx` compliant
8. - [x] license family
9. - [x] verify the build number
10. - [x] verify `setuptools`
11. - [x] verify `wheel`
    `Wheel` is not called as a requirement in the upstream
12. - [x] `pip` in the test section
    `pip` is not called as a requirement in the upstream

13. - [x] veriy the test section
 

Results:
- 
 
 
Based on the research findings and the results we can conclude
that it is safe to update `zict` to version `2.1.0`

`zict 2.1.0`
https://anaconda.atlassian.net/browse/DSNC-4963