### PR TITLE
update_2.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,10 +40,10 @@ test:
   requires:
     - pip
     - pytest
-    - pytest -k "not ({{ tests_to_skip }})"
   commands:
     - pip check
     - pytest
+    - pytest -k "not ({{ tests_to_skip }})"
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,14 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d7366c2e2293314112dcf2432108428a67b927b00005619feefc310d12d833f3
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
-  skip: True  # [py<37]
+ script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+ skip: True  # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,14 +25,19 @@ requirements:
   run:
     - python
     - heapdict
+    - python-lmdb
 
 test:
   imports:
     - zict
+  source_files:
+    - zict/tests
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ test:
     - zict/tests
   requires:
     - pip
+    - pytest
     - pytest -k "not ({{ tests_to_skip }})"
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.2.0" %}
 {% set name = "zict" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 15b2cc15f95a476fbe0623fd8f771e1e771310bf7a01f95412a0b605b6e47510
+  sha256: d7366c2e2293314112dcf2432108428a67b927b00005619feefc310d12d833f3
 
 build:
   number: 0
@@ -39,6 +39,8 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
+  description: |
+    Mutable Mapping tools.
   summary: Composable Dictionary Classes
   dev_url: https://github.com/dask/zict
   doc_url: https://zict.readthedocs.io/en/latest/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,14 @@ package:
   version: {{ version }}
 
 source:
+  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d7366c2e2293314112dcf2432108428a67b927b00005619feefc310d12d833f3
 
 build:
   number: 0
- script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
- skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,8 @@ requirements:
 
 # Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
 {% set tests_to_skip = "test_mapping" %}   #  [win]
-{% set tests_to_skip = "test_reuse" %}    #  [win]
-{% set tests_to_skip = "test_creates_dir" %}   #  [win]
+{% set tests_to_skip = tests_to_skip + " or test_reuse" %}    #  [win]
+{% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}   #  [win]
 
 test:
   imports:
@@ -39,7 +39,7 @@ test:
     - zict/tests
   requires:
     - pip
-    - pytest
+    - pytest -k "not ({{ tests_to_skip }})"
   commands:
     - pip check
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,11 @@ requirements:
     - heapdict
     - python-lmdb
 
+# Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
+{% set tests_to_skip = "test_mapping" %}   #  [win]
+{% set tests_to_skip = "test_reuse" %}    #  [win]
+{% set tests_to_skip = "test_creates_dir" %}   #  [win]
+
 test:
   imports:
     - zict
@@ -38,7 +43,6 @@ test:
   commands:
     - pip check
     - pytest
-    - test_lmdb.py tests -vv -k "not (test_mapping or test_reuse or test_creates_dir)"   #  [win]
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ test:
   commands:
     - pip check
     - pytest
-    - test_lmdb.py tests -vv -k "not (test_mapping or test_reuse or test_creates_dir)"
+    - test_lmdb.py tests -vv -k "not (test_mapping or test_reuse or test_creates_dir)"   #  [win]
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ test:
   commands:
     - pip check
     - pytest
+    - test_lmdb.py tests -vv -k "not (test_mapping or test_reuse or test_creates_dir)"
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest
-    - pytest -k "not ({{ tests_to_skip }})"
+    - pytest  # [not win]
+    - pytest zict/tests -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/mrocklin/zict


### PR DESCRIPTION
## Zict 2.2.0 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1587)
[Upstream](https://github.com/dask/zict)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added Description
- Adding `pytests`
- Skipping specified tests that causes test failure due to storage capacity for `win64`