### PR TITLE
Zict Update 3.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<39]
+  skip: True  # [py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38]
+  skip: True  # [py<39]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.2.0" %}
+{% set version = "3.0.0" %}
 {% set name = "zict" %}
 
 package:
@@ -8,12 +8,12 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d7366c2e2293314112dcf2432108428a67b927b00005619feefc310d12d833f3
+  sha256: e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<37]
+  skip: True  # [py<38]
 
 requirements:
   host:


### PR DESCRIPTION
## ☆Zict Update 3.0.0 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2266)
[Upstream](https://github.com/dask/zict/tree/3.0.0)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies