### PR TITLE
zict 3.0.0: rebuild py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
 
 {% set tests_to_skip = "" %}
 # Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
-{% set tests_to_skip = tests_to_skip +"test_mapping" %}   #  [win]
+{% set tests_to_skip = tests_to_skip + "test_mapping" %}   #  [win]
 {% set tests_to_skip = tests_to_skip + " or test_reuse" %}    #  [win]
 {% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}   #  [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,9 @@ requirements:
     - heapdict
     - python-lmdb
 
+{% set tests_to_skip = "" %}   #  [win]
 # Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
-{% set tests_to_skip = "test_mapping" %}   #  [win]
+{% set tests_to_skip = tests_to_skip +"test_mapping" %}   #  [win]
 {% set tests_to_skip = tests_to_skip + " or test_reuse" %}    #  [win]
 {% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}   #  [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - heapdict
     - python-lmdb
 
-{% set tests_to_skip = "" %}   #  [win]
+{% set tests_to_skip = "" %}
 # Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
 {% set tests_to_skip = tests_to_skip +"test_mapping" %}   #  [win]
 {% set tests_to_skip = tests_to_skip + " or test_reuse" %}    #  [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,8 @@ requirements:
     - heapdict
     - python-lmdb
 
-{% set tests_to_skip = "" %}
 # Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
-{% set tests_to_skip = tests_to_skip + "test_mapping" %}   #  [win]
+{% set tests_to_skip = "test_mapping" %}   #  [win]
 {% set tests_to_skip = tests_to_skip + " or test_reuse" %}    #  [win]
 {% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}   #  [win]
 
@@ -44,8 +43,7 @@ test:
   commands:
     - pip check
     - pytest  # [not win]
-    - pytest zict/tests -k "not ({{ tests_to_skip }})"  # [win and py<314]
-    - pytest zict/tests -k "not ({{ tests_to_skip }})" --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py  # [win and py==314]
+    - pytest zict/tests --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
     - pytest-asyncio
   commands:
     - pip check
-    - pytest  # [not win]
-    - pytest zict/tests --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest -v --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py  # [not win]
+    - pytest zict/tests -v --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py -k "not ({{ tests_to_skip }})"  # [win]
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set version = "3.0.0" %}
 {% set name = "zict" %}
+{% set tests_to_skip = "test_mapping" %}  #  [win]
+{% set tests_to_skip = tests_to_skip + " or test_reuse" %}  #  [win]
+{% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}  #  [win]
 
 package:
   name: {{ name }}
@@ -7,13 +10,13 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38]
+  skip: true  # [py<38]
 
 requirements:
   host:
@@ -21,17 +24,12 @@ requirements:
     - setuptools
     - wheel
     - pip
-
   run:
     - python
     - heapdict
     - python-lmdb
 
 # Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
-{% set tests_to_skip = "test_mapping" %}   #  [win]
-{% set tests_to_skip = tests_to_skip + " or test_reuse" %}    #  [win]
-{% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}   #  [win]
-
 test:
   imports:
     - zict
@@ -55,7 +53,6 @@ about:
   summary: Composable Dictionary Classes
   dev_url: https://github.com/dask/zict
   doc_url: https://zict.readthedocs.io/en/latest/
-
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ about:
     Mutable Mapping tools.
   summary: Composable Dictionary Classes
   dev_url: https://github.com/dask/zict
-  doc_url: https://zict.readthedocs.io/
+  doc_url: https://zict.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,8 @@ test:
   commands:
     - pip check
     - pytest  # [not win]
-    - pytest zict/tests -k "not ({{ tests_to_skip }})"  # [win or py<314]
-    - pytest zict/tests -k "not ({{ tests_to_skip }})" --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py  # [win or py==314]
+    - pytest zict/tests -k "not ({{ tests_to_skip }})"  # [win and py<314]
+    - pytest zict/tests -k "not ({{ tests_to_skip }})" --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py  # [win and py==314]
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,18 @@
 {% set version = "3.0.0" %}
 {% set name = "zict" %}
-{% set tests_to_skip = "test_mapping" %}  #  [win]
-{% set tests_to_skip = tests_to_skip + " or test_reuse" %}  #  [win]
-{% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}  #  [win]
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: e321e263b6a97aafc0790c3cfb3c04656b7066e6738c37fffcca95d803c9fba5
 
 build:
   number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -30,6 +26,10 @@ requirements:
     - python-lmdb
 
 # Skipping unnecesssary tests below as a result of low disk space on for win-64 causing build failures.
+{% set tests_to_skip = "test_mapping" %}   #  [win]
+{% set tests_to_skip = tests_to_skip + " or test_reuse" %}    #  [win]
+{% set tests_to_skip = tests_to_skip + " or test_creates_dir" %}   #  [win]
+
 test:
   imports:
     - zict
@@ -38,6 +38,8 @@ test:
   requires:
     - pip
     - pytest
+    # for tests/test_async_buffer.py
+    - pytest-tornasync
   commands:
     - pip check
     - pytest  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,8 @@ test:
   commands:
     - pip check
     - pytest  # [not win]
-    - pytest zict/tests -k "not ({{ tests_to_skip }})"  # [win]
+    - pytest zict/tests -k "not ({{ tests_to_skip }})"  # [win or py<314]
+    - pytest zict/tests -k "not ({{ tests_to_skip }})" --ignore=zict/tests/test_lmdb.py --ignore=zict/tests/test_lru.py  # [win or py==314]
 
 about:
   home: https://github.com/mrocklin/zict

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ about:
     Mutable Mapping tools.
   summary: Composable Dictionary Classes
   dev_url: https://github.com/dask/zict
-  doc_url: https://zict.readthedocs.io/en/latest/
+  doc_url: https://zict.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
     - pip
     - pytest
     # for tests/test_async_buffer.py
-    - pytest-tornasync
+    - pytest-asyncio
   commands:
     - pip check
     - pytest  # [not win]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11059) 
- [Upstream repository](https://github.com/dask/zict/tree/3.0.0)

### Explanation of changes:

- Add `pytest-asyncio` for `tests/test_async_buffer.py` to avoid an error `async def functions are not natively supported.
You need to install a suitable plugin for your async framework`
- Ignore `zict/tests/test_lmdb.py` and `zict/tests/test_lru.py` because our CI can get stuck without any messages.

### Notes:

-